### PR TITLE
Combination HUD

### DIFF
--- a/LSLScripts/HUD/Ruth/Serie Sumei/hud-maker.lsl
+++ b/LSLScripts/HUD/Ruth/Serie Sumei/hud-maker.lsl
@@ -1,0 +1,168 @@
+//*********************************************************************************
+//**   This program is free software: you can redistribute it and/or modify
+//**   it under the terms of the GNU Affero General Public License as
+//**   published by the Free Software Foundation, either version 3 of the
+//**   License, or (at your option) any later version.
+//**
+//**   This program is distributed in the hope that it will be useful,
+//**   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//**   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//**   GNU Affero General Public License for more details.
+//**
+//**   You should have received a copy of the GNU Affero General Public License
+//**   along with this program.  If not, see <https://www.gnu.org/licenses/>
+//*********************************************************************************
+
+// ss-c 31Dec2018 <seriesumei@avimail.org> - Combined HUD
+
+// Build a single HUD for Ruth/Roth for alpha and skin appliers:
+// * Upload or obtain via whatever means the Alpha HUD mesh and the 'doll' mesh.  This
+//   script will throw an error if you start with a pre-linked Alpha HUD but it should
+//   work anyway.  Remove any scripts in these meshes.
+// * Create a new prim and take a copy of it into inventory
+// * Copy the folloing objects into the new prim on the ground:
+//   * the new prim from inventory created above and name it 'Object'
+//   * the alpha HUD mesh into the root prim and name it 'alpha-hud'
+//   * the doll mesh into the root prim and name it 'doll' if it is not already linked
+//     to the ahpha HUD mesh
+//   * this script
+// * Light fuse (touch the new prim) and get away, the new HUD will be assembled
+//   around the new prim which is now the root prim of the HUD.
+// * The alpha HUD and the doll will not be linked as they may need size and/or
+//   position adjustments depending on how your mesh is linked and what their original
+//   root prim was.
+// * Rename the former root prim of the alpha HUD mesh, if it was the rotation bar
+//   at the bottom name it 'rotatebar'.  Remove any script if it is still present.
+// * Rename the former root prim of the doll according to the usual doll link names.
+// * Make any position and size adjustments as necessary to the alpha HUD mesh and
+//   doll, then link them both to the new HUD root prim.  Make sure that the center
+//   square HUD prim is last so it remains the root of the linkset.
+// * Remove this script from the HUD root prim and copy in the ss-c version of the
+//   ru2HUD_ac_trigger HUD script.
+// * The other objects are also not needed any longer in the root prim and can be removed.
+
+vector build_pos;
+integer link_me = FALSE;
+integer FINI = FALSE;
+
+key bar_texture = "332b97c3-d7c0-f2e5-732a-16ead0d8ba02";
+vector bar_size = <0.5, 0.5, 0.04>;
+
+// Spew debug info
+integer VERBOSE = TRUE;
+
+log(string txt) {
+    if (VERBOSE) {
+        llOwnerSay(txt);
+    }
+}
+
+rez_object(string name, vector delta, vector rot) {
+    vector build_pos = llGetPos();
+    build_pos += delta;;
+
+    log("Rezzing " + name);
+    llRezObject(
+        name,
+        build_pos,
+        <0.0, 0.0, 0.0>,
+        llEuler2Rot(rot),
+        0
+    );
+}
+
+default {
+    touch_start(integer total_number) {
+        // set up root prim
+        log("Configuring root");
+        llSetLinkPrimitiveParamsFast(LINK_THIS, [
+            PRIM_NAME, "HUD base",
+            PRIM_SIZE, <0.1, 0.1, 0.1>,
+            PRIM_TEXTURE, ALL_SIDES, TEXTURE_TRANSPARENT, <0,0,0>, <0.0, 0.455, 0.0>, 0.0,
+            PRIM_COLOR, ALL_SIDES, <1.0, 1.0, 1.0>, 1.00
+        ]);
+
+        // See if we'll be able to link to trigger build
+        llRequestPermissions(llGetOwner(), PERMISSION_CHANGE_LINKS);
+    }
+
+    run_time_permissions(integer perm) {
+        // Only bother rezzing the object if will be able to link it.
+        if (perm & PERMISSION_CHANGE_LINKS) {
+            log("Rezzing south");
+            link_me = TRUE;
+            rez_object("Object", <0.0, 0.0, -0.5>, <0.0, 0.0, 0.0>);
+        } else {
+            llOwnerSay("unable to link objects, aborting build");
+        }
+    }
+
+    object_rez(key id) {
+        integer i = llGetNumberOfPrims();
+        log("i="+(string)i);
+
+        if (link_me) {
+            llCreateLink(id, TRUE);
+            link_me = FALSE;
+        }
+
+        if (i == 1) {
+            log("Configuring south");
+            llSetLinkPrimitiveParamsFast(2, [
+                PRIM_NAME, "minbar",
+                PRIM_TEXTURE, ALL_SIDES, bar_texture, <1, 0.08, 0>, <0.0, 0.455, 0.0>, 0.0,
+                PRIM_COLOR, ALL_SIDES, <1.0, 1.0, 1.0>, 1.00,
+                PRIM_SIZE, bar_size
+            ]);
+            llSetLinkTexture(2, bar_texture, ALL_SIDES);
+            log("Rezzing north");
+            link_me = TRUE;
+            rez_object("Object", <0.0, 0.0, 0.5>, <PI, 0.0, 0.0>);
+        }
+        else if (i == 2) {
+            log("Configuring north");
+            llSetLinkPrimitiveParamsFast(2, [
+                PRIM_NAME, "alphabar",
+                PRIM_TEXTURE, ALL_SIDES, bar_texture, <1, 0.08, 0>, <0.0, 0.455, 0.0>, 0.0,
+                PRIM_COLOR, ALL_SIDES, <1.0, 1.0, 1.0>, 1.00,
+                PRIM_SIZE, bar_size
+            ]);
+            llSetLinkTexture(2, bar_texture, ALL_SIDES);
+            log("Rezzing east");
+            link_me = TRUE;
+            rez_object("Object", <0.0, -0.5, 0.0>, <-PI_BY_TWO, 0.0, 0.0>);
+        }
+        else if (i == 3) {
+            log("Configuring east");
+            llSetLinkPrimitiveParamsFast(2, [
+                PRIM_NAME, "skinbar",
+                PRIM_TEXTURE, ALL_SIDES, bar_texture, <1, 0.08, 0>, <0.0, 0.455, 0.0>, 0.0,
+                PRIM_COLOR, ALL_SIDES, <1.0, 1.0, 1.0>, 1.00,
+                PRIM_SIZE, bar_size
+            ]);
+            llSetLinkTexture(2, bar_texture, ALL_SIDES);
+            log("Rezzing west");
+            link_me = TRUE;
+            rez_object("Object", <0.0, 0.5, 0.0>, <PI_BY_TWO, 0.0, 0.0>);
+        }
+        else if (i == 4) {
+            log("Configuring west");
+            llSetLinkPrimitiveParamsFast(2, [
+                PRIM_NAME, "westbar",
+                PRIM_TEXTURE, ALL_SIDES, bar_texture, <1, 0.08, 0>, <0.0, 0.455, 0.0>, 0.0,
+                PRIM_COLOR, ALL_SIDES, <1.0, 1.0, 1.0>, 1.00,
+                PRIM_SIZE, bar_size
+            ]);
+            llSetLinkTexture(2, bar_texture, ALL_SIDES);
+            log("Rezzing alpha HUD");
+            link_me = FALSE;
+            rez_object("alpha-hud", <0.0, 0.0, 1.38>, <PI, 0.0, -PI_BY_TWO>);
+        }
+        else if (i == 5 && ! FINI) {
+            FINI = TRUE;
+            log("Rezzing alpha doll");
+            link_me = FALSE;
+            rez_object("doll", <0.0, 0.0, 0.9>, <PI, 0.0, -PI_BY_TWO>);
+        }
+    }
+}

--- a/LSLScripts/HUD/Ruth/Serie Sumei/ru2HUD_ac_trigger.lsl
+++ b/LSLScripts/HUD/Ruth/Serie Sumei/ru2HUD_ac_trigger.lsl
@@ -1,0 +1,337 @@
+//*********************************************************************************
+//**   Copyright (C) 2017  Shin Ingen
+//**
+//**   This program is free software: you can redistribute it and/or modify
+//**   it under the terms of the GNU Affero General Public License as
+//**   published by the Free Software Foundation, either version 3 of the
+//**   License, or (at your option) any later version.
+//**
+//**   This program is distributed in the hope that it will be useful,
+//**   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//**   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//**   GNU Affero General Public License for more details.
+//**
+//**   You should have received a copy of the GNU Affero General Public License
+//**   along with this program.  If not, see <https://www.gnu.org/licenses/>
+//*********************************************************************************
+integer r2chan;
+integer appID = 20181024;
+integer keyapp2chan()
+{
+    return 0x80000000 | ((integer)("0x"+(string)llGetOwner()) ^ appID);
+}
+vector            alphaOnColor =     <0.000, 0.000, 0.000>;
+vector            buttonOnColor =     <0.000, 1.000, 0.000>;
+vector            offColor =         <1.000, 1.000, 1.000>;
+list              commandButtonList =    [
+"reset",
+
+"backupper::backupper::30::-1",
+"backlower::backlower::31::-1",
+
+"chest::chest::32::-1",
+"breasts::breastright::33::-1",
+"breasts::breastleft::34::-1",
+"nipples::breastright::33::0",
+"nipples::breastleft::34::0",
+"belly::belly::35::-1",
+
+"armsupper::armright::36::0",
+"armsupper::armright::36::1",
+"armsupper::armright::36::2",
+"armsupper::armright::36::3",
+"armsupper::armleft::37::0",
+"armsupper::armleft::37::1",
+"armsupper::armleft::37::2",
+"armsupper::armleft::37::3",
+
+"armslower::armright::36::4",
+"armslower::armright::36::5",
+"armslower::armright::36::6",
+"armslower::armright::36::7",
+"armslower::armleft::37::4",
+"armslower::armleft::37::5",
+"armslower::armleft::37::6",
+"armslower::armleft::37::7",
+
+"armsfull::armright::36::-1",
+"armsfull::armleft::37::-1",
+
+"hands::hands::38::-1",
+
+"buttcrotch::pelvisback::11::7",
+"buttcrotch::pelvisfront::12::5",
+"buttcrotch::pelvisfront::12::6",
+"buttcrotch::pelvisfront::12::7",
+"pelvis::pelvisback::11::-1",
+"pelvis::pelvisfront::12::-1",
+
+"legsupper::legright1::13::-1",
+"legsupper::legright2::14::-1",
+"legsupper::legright3::15::-1",
+"legsupper::legleft1::21::-1",
+"legsupper::legleft2::22::-1",
+"legsupper::legleft3::23::-1",
+
+"knees::legright4::16::-1",
+"knees::legright5::17::-1",
+"knees::legleft4::24::-1",
+"knees::legleft5::25::-1",
+
+"legslower::legright6::18::-1",
+"legslower::legright7::19::-1",
+"legslower::legright8::20::-1",
+"legslower::legleft6::26::-1",
+"legslower::legleft7::27::-1",
+"legslower::legleft8::28::-1",
+
+"legsfull::legright1::13::-1",
+"legsfull::legright2::14::-1",
+"legsfull::legright3::15::-1",
+"legsfull::legright4::16::-1",
+"legsfull::legright5::17::-1",
+"legsfull::legright6::18::-1",
+"legsfull::legright7::19::-1",
+"legsfull::legright8::20::-1",
+"legsfull::legleft1::21::-1",
+"legsfull::legleft2::22::-1",
+"legsfull::legleft3::23::-1",
+"legsfull::legleft4::24::-1",
+"legsfull::legleft5::25::-1",
+"legsfull::legleft6::26::-1",
+"legsfull::legleft7::27::-1",
+"legsfull::legleft8::28::-1",
+
+"feet::feet::29::-1",
+"ankles::feet::29::0",
+"bridges::feet::29::1",
+"bridges::feet::29::2",
+"toecleavages::feet::29::3",
+"toes::feet::29::4",
+"soles::feet::29::5",
+"heels::feet::29::6"
+    ];
+
+resetallalpha()
+{
+    integer i;
+    integer x = llGetNumberOfPrims()+1;
+
+    for (; i < x; ++i)
+    {
+        llSetLinkPrimitiveParamsFast(i, [PRIM_COLOR, -1, offColor, 1.0]);
+        if(i>=9)
+        {
+            list paramList = llGetLinkPrimitiveParams(i,[PRIM_NAME]);
+            string primName = llList2String(paramList,0);
+            string message = "ALPHA," + (string)primName + "," + "-1" + "," + "1";
+            llSay(r2chan,message);
+        }
+    }
+}
+
+colorDoll(string commandFilter, integer alphaVal)
+{
+    integer i;
+    integer x = llGetListLength(commandButtonList)+1;
+    for (; i < x; ++i)
+    {
+        string dataString = llList2String(commandButtonList,i);
+        list stringList = llParseString2List(dataString, ["::"], []);
+        string command = llList2String(stringList,0);
+        string primName = llList2String(stringList,1);
+        integer primLink = llList2Integer(stringList,2);
+        integer primFace = llList2Integer(stringList,3);
+        string message = "ALPHA," + (string)primName + "," + (string)primFace + "," + (string)alphaVal;
+
+        if (command == commandFilter)
+        {
+            if (alphaVal == 0)
+            {
+                llSetLinkPrimitiveParamsFast(primLink, [PRIM_COLOR, primFace, alphaOnColor, 1.0]);
+                llSay(r2chan,message);
+            }
+            else
+            {
+                llSetLinkPrimitiveParamsFast(primLink, [PRIM_COLOR, primFace, offColor, 1.0]);
+                llSay(r2chan,message);
+            }
+        }
+    }
+}
+
+default
+{
+    state_entry()
+    {
+        r2chan = keyapp2chan();
+    }
+
+    on_rez(integer param)
+    {
+        llResetScript();
+    }
+
+    touch_start(integer total_number)
+    {
+        integer link = llDetectedLinkNumber(0);
+        integer face = llDetectedTouchFace(0);
+
+        if(link == 1)
+        {
+            if(face == 1||face == 3||face == 5||face == 7)
+            {
+                rotation localRot = llList2Rot(llGetLinkPrimitiveParams(link,[PRIM_ROT_LOCAL]),0);
+                llSetLinkPrimitiveParamsFast(link,[PRIM_ROT_LOCAL,llEuler2Rot(<0.0,0.0,PI/2>)*localRot]);
+            }
+            else
+            {
+                rotation localRot = llList2Rot(llGetLinkPrimitiveParams(link,[PRIM_ROT_LOCAL]),0);
+                llSetLinkPrimitiveParamsFast(link,[PRIM_ROT_LOCAL,llEuler2Rot(<0.0,0.0,-PI/2>)*localRot]);
+            }
+        }
+        else if(link == 3 || link == 7)
+        {
+            list buttonList = [
+                    "reset",
+                    "chest",
+                    "breasts",
+                    "nipples",
+                    "belly",
+                    "backupper",
+                    "backlower",
+                    "armsupper"
+                    ];
+            if(face == 0)
+            {
+                resetallalpha();
+            }
+            else
+            {
+                string commandButton = llList2String(buttonList,face);
+                list paramList = llGetLinkPrimitiveParams(link,[PRIM_NAME,PRIM_COLOR,face]);
+                string primName = llList2String(paramList,0);
+                vector primColor = llList2Vector(paramList,1);
+                integer alphaVal;
+                if (primColor == offColor)
+                {
+                    alphaVal=0;
+                    llSetLinkPrimitiveParamsFast(3, [PRIM_COLOR, face, buttonOnColor, 1.0]);
+                    llSetLinkPrimitiveParamsFast(7, [PRIM_COLOR, face, buttonOnColor, 1.0]);
+                }
+                else
+                {
+                    alphaVal=1;
+                    llSetLinkPrimitiveParamsFast(3, [PRIM_COLOR, face, offColor, 1.0]);
+                    llSetLinkPrimitiveParamsFast(7, [PRIM_COLOR, face, offColor, 1.0]);
+                }
+                colorDoll(commandButton,alphaVal);
+                //llOwnerSay(0,"Link:" + (string)link + " Button:" + commandButton);
+            }
+        }
+        else if(link == 4 || link == 8)
+        {
+            list buttonList = [
+                    "armslower",
+                    "armsfull",
+                    "hands",
+                    "buttcrotch",
+                    "pelvis",
+                    "legsupper",
+                    "knees",
+                    "legslower"
+                    ];
+            string commandButton = llList2String(buttonList,face);
+            list paramList = llGetLinkPrimitiveParams(link,[PRIM_NAME,PRIM_COLOR,face]);
+            string primName = llList2String(paramList,0);
+            vector primColor = llList2Vector(paramList,1);
+            integer alphaVal;
+
+            if (primColor == offColor)
+            {
+                alphaVal=0;
+                llSetLinkPrimitiveParamsFast(4, [PRIM_COLOR, face, buttonOnColor, 1.0]);
+                llSetLinkPrimitiveParamsFast(8, [PRIM_COLOR, face, buttonOnColor, 1.0]);
+            }
+            else
+            {
+                alphaVal=1;
+                llSetLinkPrimitiveParamsFast(4, [PRIM_COLOR, face, offColor, 1.0]);
+                llSetLinkPrimitiveParamsFast(8, [PRIM_COLOR, face, offColor, 1.0]);
+            }
+
+            colorDoll(commandButton,alphaVal);
+        }
+        else if(link == 5 || link == 9)
+        {
+            list buttonList = [
+                    "legsfull",
+                    "feet",
+                    "ankles",
+                    "heels",
+                    "bridges",
+                    "toecleavages",
+                    "toes",
+                    "soles"
+                    ];
+            string commandButton = llList2String(buttonList,face);
+            list paramList = llGetLinkPrimitiveParams(link,[PRIM_NAME,PRIM_COLOR,face]);
+            string primName = llList2String(paramList,0);
+            vector primColor = llList2Vector(paramList,1);
+            integer alphaVal;
+
+            if (primColor == offColor)
+            {
+                alphaVal=0;
+                llSetLinkPrimitiveParamsFast(5, [PRIM_COLOR, face, buttonOnColor, 1.0]);
+                llSetLinkPrimitiveParamsFast(9, [PRIM_COLOR, face, buttonOnColor, 1.0]);
+            }
+            else
+            {
+                alphaVal=1;
+                llSetLinkPrimitiveParamsFast(5, [PRIM_COLOR, face, offColor, 1.0]);
+                llSetLinkPrimitiveParamsFast(9, [PRIM_COLOR, face, offColor, 1.0]);
+            }
+            colorDoll(commandButton,alphaVal);
+        }
+        else if(link == 6 || link == 10)
+        {
+            list buttonList = [
+                    "--",
+                    "--",
+                    "--",
+                    "--",
+                    "--",
+                    "--",
+                    "savealpha",
+                    "loadalpha"
+                    ];
+            string commandButton = llList2String(buttonList,face);
+            llOwnerSay("Saving and loading alpha is not yet implemented!");
+        }
+        else if(link == 2)
+        {
+            //ignore click on backboard
+        }
+        else
+        {
+            list paramList = llGetLinkPrimitiveParams(link,[PRIM_NAME,PRIM_COLOR,face]);
+            string primName = llList2String(paramList,0);
+            vector primColor = llList2Vector(paramList,1);
+            integer alphaVal;
+
+            if (primColor == offColor)
+            {
+                alphaVal=0;
+                llSetLinkPrimitiveParamsFast(link, [PRIM_COLOR, face, alphaOnColor, 1.0]);
+            }
+            else
+            {
+                alphaVal=1;
+                llSetLinkPrimitiveParamsFast(link, [PRIM_COLOR, face, offColor, 1.0]);
+            }
+            string message = "ALPHA," + (string)primName + "," + (string)face + "," + (string)alphaVal;
+            llSay(r2chan,message);
+        }
+    }
+}

--- a/LSLScripts/HUD/Ruth/Serie Sumei/ru2HUD_combined.lsl
+++ b/LSLScripts/HUD/Ruth/Serie Sumei/ru2HUD_combined.lsl
@@ -1,0 +1,449 @@
+//*********************************************************************************
+//**   Copyright (C) 2017  Shin Ingen
+//**
+//**   This program is free software: you can redistribute it and/or modify
+//**   it under the terms of the GNU Affero General Public License as
+//**   published by the Free Software Foundation, either version 3 of the
+//**   License, or (at your option) any later version.
+//**
+//**   This program is distributed in the hope that it will be useful,
+//**   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//**   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//**   GNU Affero General Public License for more details.
+//**
+//**   You should have received a copy of the GNU Affero General Public License
+//**   along with this program.  If not, see <https://www.gnu.org/licenses/>
+//*********************************************************************************
+
+// ss-a 29Dec2018 <seriesumei@avimail.org> - Make alpha hud link-order independent
+// ss-b 30Dec2018 <seriesumei@avimail.org> - Auto-adjust position on attach
+// ss-c 31Dec2018 <seriesumei@avimail.org> - Combined HUD
+
+integer r2chan;
+integer appID = 20181024;
+integer keyapp2chan()
+{
+    return 0x80000000 | ((integer)("0x"+(string)llGetOwner()) ^ appID);
+}
+vector            alphaOnColor =     <0.000, 0.000, 0.000>;
+vector            buttonOnColor =     <0.000, 1.000, 0.000>;
+vector            offColor =         <1.000, 1.000, 1.000>;
+
+// The command button list is:
+//  <button-name> :: <prim-name> :: <link-number> :: <face-number>
+// <link-number> is no longer used, replaced with the index in
+// prim_map that is built at script startup, thus relieving us
+// of the perils of not liking the HUD in the right order
+
+list              commandButtonList =    [
+"reset",
+
+"backupper::backupper::30::-1",
+"backlower::backlower::31::-1",
+
+"chest::chest::32::-1",
+"breasts::breastright::33::-1",
+"breasts::breastleft::34::-1",
+"nipples::breastright::33::0",
+"nipples::breastleft::34::0",
+"belly::belly::35::-1",
+
+"armsupper::armright::36::0",
+"armsupper::armright::36::1",
+"armsupper::armright::36::2",
+"armsupper::armright::36::3",
+"armsupper::armleft::37::0",
+"armsupper::armleft::37::1",
+"armsupper::armleft::37::2",
+"armsupper::armleft::37::3",
+
+"armslower::armright::36::4",
+"armslower::armright::36::5",
+"armslower::armright::36::6",
+"armslower::armright::36::7",
+"armslower::armleft::37::4",
+"armslower::armleft::37::5",
+"armslower::armleft::37::6",
+"armslower::armleft::37::7",
+
+"armsfull::armright::36::-1",
+"armsfull::armleft::37::-1",
+
+"hands::hands::38::-1",
+
+"buttcrotch::pelvisback::11::7",
+"buttcrotch::pelvisfront::12::5",
+"buttcrotch::pelvisfront::12::6",
+"buttcrotch::pelvisfront::12::7",
+"pelvis::pelvisback::11::-1",
+"pelvis::pelvisfront::12::-1",
+
+"legsupper::legright1::13::-1",
+"legsupper::legright2::14::-1",
+"legsupper::legright3::15::-1",
+"legsupper::legleft1::21::-1",
+"legsupper::legleft2::22::-1",
+"legsupper::legleft3::23::-1",
+
+"knees::legright4::16::-1",
+"knees::legright5::17::-1",
+"knees::legleft4::24::-1",
+"knees::legleft5::25::-1",
+
+"legslower::legright6::18::-1",
+"legslower::legright7::19::-1",
+"legslower::legright8::20::-1",
+"legslower::legleft6::26::-1",
+"legslower::legleft7::27::-1",
+"legslower::legleft8::28::-1",
+
+"legsfull::legright1::13::-1",
+"legsfull::legright2::14::-1",
+"legsfull::legright3::15::-1",
+"legsfull::legright4::16::-1",
+"legsfull::legright5::17::-1",
+"legsfull::legright6::18::-1",
+"legsfull::legright7::19::-1",
+"legsfull::legright8::20::-1",
+"legsfull::legleft1::21::-1",
+"legsfull::legleft2::22::-1",
+"legsfull::legleft3::23::-1",
+"legsfull::legleft4::24::-1",
+"legsfull::legleft5::25::-1",
+"legsfull::legleft6::26::-1",
+"legsfull::legleft7::27::-1",
+"legsfull::legleft8::28::-1",
+
+"feet::feet::29::-1",
+"ankles::feet::29::0",
+"bridges::feet::29::1",
+"bridges::feet::29::2",
+"toecleavages::feet::29::3",
+"toes::feet::29::4",
+"soles::feet::29::5",
+"heels::feet::29::6"
+    ];
+
+// Keep a mapping of link number to prim name
+list prim_map = [];
+
+// HUD Positioning offsets
+float bottom_offset = 1.36;
+float left_offset = -0.22;
+float right_offset = 0.22;
+float top_offset = 0.46;
+integer last_attach = 0;
+
+vector MIN_BAR = <0.0, 0.0, 0.0>;
+vector ALPHA_HUD = <PI, 0.0, 0.0>;
+vector SKIN_HUD = <PI_BY_TWO, 0.0, 0.0>;
+vector alpha_rot = ALPHA_HUD;
+vector last_rot = MIN_BAR;
+
+integer VERBOSE = FALSE;
+
+log(string msg) {
+    if (VERBOSE == 1) {
+        llOwnerSay(msg);
+    }
+}
+
+vector get_size() {
+    return llList2Vector(llGetPrimitiveParams([PRIM_SIZE]), 0);
+}
+
+adjust_pos() {
+    integer current_attach = llGetAttached();
+
+    // See if attachpoint has changed
+    if ((current_attach > 0 && current_attach != last_attach) ||
+            (last_attach == 0)) {
+        vector size = get_size();
+
+        // Nasty if else block
+        if (current_attach == ATTACH_HUD_TOP_LEFT) {
+            llSetPos(<0.0, left_offset - size.y / 2, top_offset - size.z / 2>);
+        }
+        else if (current_attach == ATTACH_HUD_TOP_CENTER) {
+            llSetPos(<0.0, 0.0, top_offset - size.z / 2>);
+        }
+        else if (current_attach == ATTACH_HUD_TOP_RIGHT) {
+            llSetPos(<0.0, right_offset + size.y / 2, top_offset - size.z / 2>);
+        }
+        else if (current_attach == ATTACH_HUD_BOTTOM_LEFT) {
+            llSetPos(<0.0, left_offset - size.y / 2, bottom_offset + size.z / 2>);
+        }
+        else if (current_attach == ATTACH_HUD_BOTTOM) {
+            llSetPos(<0.0, 0.0, bottom_offset + size.z / 2>);
+        }
+        else if (current_attach == ATTACH_HUD_BOTTOM_RIGHT) {
+            llSetPos(<0.0, right_offset + size.y / 2, bottom_offset + size.z / 2>);
+        }
+        else if (current_attach == ATTACH_HUD_CENTER_1) {
+        }
+        else if (current_attach == ATTACH_HUD_CENTER_2) {
+        }
+        last_attach = current_attach;
+    }
+}
+
+resetallalpha()
+{
+    integer i;
+    integer x = llGetNumberOfPrims()+1;
+
+    for (; i < x; ++i)
+    {
+        llSetLinkPrimitiveParamsFast(i, [PRIM_COLOR, -1, offColor, 1.0]);
+        if(i>=9)
+        {
+            list paramList = llGetLinkPrimitiveParams(i,[PRIM_NAME]);
+            string primName = llList2String(paramList,0);
+            string message = "ALPHA," + (string)primName + "," + "-1" + "," + "1";
+            llSay(r2chan,message);
+        }
+    }
+}
+
+colorDoll(string commandFilter, integer alphaVal)
+{
+    integer i;
+    integer x = llGetListLength(commandButtonList)+1;
+    integer num_links = llGetNumberOfPrims() + 1;
+    for (; i < x; ++i)
+    {
+        string dataString = llList2String(commandButtonList,i);
+        list stringList = llParseString2List(dataString, ["::"], []);
+        string command = llList2String(stringList,0);
+
+        if (command == commandFilter)
+        {
+            string primName = llList2String(stringList,1);
+            integer j;
+            for (; j < num_links; ++j) {
+                // Set color for all matching link nmaes
+                if (llList2String(prim_map, j) == primName) {
+                    integer primLink = j;
+                    integer primFace = llList2Integer(stringList,3);
+                    string message = "ALPHA," + (string)primName + "," + (string)primFace + "," + (string)alphaVal;
+
+                    if (alphaVal == 0)
+                    {
+                        llSetLinkPrimitiveParamsFast(primLink, [PRIM_COLOR, primFace, alphaOnColor, 1.0]);
+                        llSay(r2chan,message);
+                    }
+                    else
+                    {
+                        llSetLinkPrimitiveParamsFast(primLink, [PRIM_COLOR, primFace, offColor, 1.0]);
+                        llSay(r2chan,message);
+                    }
+                }
+            }
+        }
+    }
+}
+
+doButtonPress(list buttons, integer link, integer face) {
+    string commandButton = llList2String(buttons, face);
+    list paramList = llGetLinkPrimitiveParams(link, [PRIM_NAME, PRIM_COLOR, face]);
+    string primName = llList2String(paramList, 0);
+    vector primColor = llList2Vector(paramList, 1);
+    string name = llGetLinkName(link);
+
+    integer alphaVal;
+    integer i;
+    integer num_links = llGetNumberOfPrims() + 1;
+    log("doButtonPress(): "+primName+" "+(string)link+" "+(string)face);
+    for (; i < num_links; ++i) {
+        // Set color for all matching link nmaes
+        if (llList2String(prim_map, i) == name) {
+            if (primColor == offColor) {
+                alphaVal = 0;
+                llSetLinkPrimitiveParamsFast(i, [PRIM_COLOR, face, buttonOnColor, 1.0]);
+            } else {
+                alphaVal = 1;
+                llSetLinkPrimitiveParamsFast(i, [PRIM_COLOR, face, offColor, 1.0]);
+            }
+        }
+    }
+    colorDoll(commandButton, alphaVal);
+}
+
+default
+{
+    state_entry()
+    {
+        r2chan = keyapp2chan();
+
+        // Create map of all links to prim names
+        integer i;
+        integer num_links = llGetNumberOfPrims() + 1;
+        for (; i < num_links; ++i) {
+            list p = llGetLinkPrimitiveParams(i, [PRIM_NAME]);
+            prim_map += [llList2String(p, 0)];
+        }
+
+        // Initialize attach state
+        last_attach = llGetAttached();
+        log("state_entry() attached="+(string)last_attach);
+    }
+
+    on_rez(integer param)
+    {
+//        llResetScript();
+    }
+
+    touch_start(integer total_number)
+    {
+        integer link = llDetectedLinkNumber(0);
+        integer face = llDetectedTouchFace(0);
+        vector pos = llDetectedTouchST(0);
+        string name = llGetLinkName(link);
+
+        if (name == "rotatebar") {
+            if(face == 1||face == 3||face == 5||face == 7)
+            {
+                rotation localRot = llList2Rot(llGetLinkPrimitiveParams(LINK_ROOT,[PRIM_ROT_LOCAL]),0);
+                llSetLinkPrimitiveParamsFast(LINK_ROOT,[PRIM_ROT_LOCAL,llEuler2Rot(<0.0,0.0,-PI/2>)*localRot]);
+            }
+            else
+            {
+                rotation localRot = llList2Rot(llGetLinkPrimitiveParams(LINK_ROOT,[PRIM_ROT_LOCAL]),0);
+                llSetLinkPrimitiveParamsFast(LINK_ROOT,[PRIM_ROT_LOCAL,llEuler2Rot(<0.0,0.0,PI/2>)*localRot]);
+            }
+            // Save current alpha rotation
+            alpha_rot = llRot2Euler(llList2Rot(llGetLinkPrimitiveParams(LINK_ROOT,[PRIM_ROT_LOCAL]),0));
+        }
+        else if (name == "minbar" || name == "alphabar" || name == "skinbar") {
+            integer bx = (integer)(pos.x * 10);
+            integer by = (integer)(pos.y * 10);
+            log("x,y="+(string)bx+","+(string)by);
+
+            if (bx == 4 || bx == 5) {
+                // skin
+                llSetLinkPrimitiveParamsFast(LINK_ROOT,[PRIM_ROT_LOCAL,llEuler2Rot(SKIN_HUD)]);
+            }
+            else if (bx == 6 || bx == 7) {
+                // alpha
+                llSetLinkPrimitiveParamsFast(LINK_ROOT,[PRIM_ROT_LOCAL,llEuler2Rot(alpha_rot)]);
+            }
+            else if (bx == 8) {
+                // min
+                vector next_rot = MIN_BAR;
+
+                if (last_rot == MIN_BAR) {
+                    // Save current rotation for later
+                    last_rot = llRot2Euler(llList2Rot(llGetLinkPrimitiveParams(LINK_ROOT,[PRIM_ROT_LOCAL]),0));
+                } else {
+                    // Restore last rotation
+                    next_rot = last_rot;
+                    last_rot = MIN_BAR;
+                }
+                llSetLinkPrimitiveParamsFast(LINK_ROOT,[PRIM_ROT_LOCAL,llEuler2Rot(next_rot)]);
+            }
+            else if (bx == 9) {
+                log("DETACH!");
+                llRequestPermissions(llDetectedKey(0), PERMISSION_ATTACH);
+            }
+        }
+        else if (name == "buttonbar1" || name == "buttonbar5") {
+            list buttonList = [
+                    "reset",
+                    "chest",
+                    "breasts",
+                    "nipples",
+                    "belly",
+                    "backupper",
+                    "backlower",
+                    "armsupper"
+                    ];
+            if(face == 0)
+            {
+                resetallalpha();
+            }
+            else
+            {
+                doButtonPress(buttonList, link, face);
+            }
+        }
+        else if (name == "buttonbar2" || name == "buttonbar6") {
+            list buttonList = [
+                    "armslower",
+                    "armsfull",
+                    "hands",
+                    "buttcrotch",
+                    "pelvis",
+                    "legsupper",
+                    "knees",
+                    "legslower"
+                    ];
+            doButtonPress(buttonList, link, face);
+        }
+        else if (name == "buttonbar3" || name == "buttonbar7") {
+            list buttonList = [
+                    "legsfull",
+                    "feet",
+                    "ankles",
+                    "heels",
+                    "bridges",
+                    "toecleavages",
+                    "toes",
+                    "soles"
+                    ];
+            doButtonPress(buttonList, link, face);
+        }
+        else if (name == "buttonbar4" || name == "buttonbar8") {
+            list buttonList = [
+                    "--",
+                    "--",
+                    "--",
+                    "--",
+                    "--",
+                    "--",
+                    "savealpha",
+                    "loadalpha"
+                    ];
+            string commandButton = llList2String(buttonList,face);
+            llOwnerSay("Saving and loading alpha is not yet implemented!");
+        }
+        else if(name == "backboard")
+        {
+            //ignore click on backboard
+        }
+        else
+        {
+            list paramList = llGetLinkPrimitiveParams(link,[PRIM_NAME,PRIM_COLOR,face]);
+            string primName = llList2String(paramList,0);
+            vector primColor = llList2Vector(paramList,1);
+            integer alphaVal;
+
+            if (primColor == offColor)
+            {
+                alphaVal=0;
+                llSetLinkPrimitiveParamsFast(link, [PRIM_COLOR, face, alphaOnColor, 1.0]);
+            }
+            else
+            {
+                alphaVal=1;
+                llSetLinkPrimitiveParamsFast(link, [PRIM_COLOR, face, offColor, 1.0]);
+            }
+            string message = "ALPHA," + (string)primName + "," + (string)face + "," + (string)alphaVal;
+            llSay(r2chan,message);
+        }
+    }
+
+    run_time_permissions(integer perm) {
+        if (perm & PERMISSION_ATTACH) {
+            llDetachFromAvatar();
+        }
+    }
+
+    attach(key id) {
+        if (id == NULL_KEY) {
+            // Nothing to do on detach?
+        } else {
+            // Fix up our location
+            adjust_pos();
+        }
+    }
+}


### PR DESCRIPTION
This is the start of combining the alpha and skin applier HUDs into a single multi-panel HUD.  The skin applier panel is not yet present, this is an experiment to see if this is workable and a desirable direction.

The HUD currently only displays the alpha panel and a minimized bar similar to a menu bar.  To do this requires rotating the HUD and to do that cleanly required using a new root prim and adding a couple more prim for the menu bars.  The easiest way to build this is via a maker script so I added one. :)

There is also a copy of this HUD in my store to play with if you don't want to go through the fun of making one from scratch.  http://maps.secondlife.com/secondlife/Fireheart/76/28/2099

This builds on the prior alpha HUD work in https://github.com/ingen-lab/Ruth/pull/40 (hopefully a second PR doesn't mess that one up).  And the texture used is left over from an earlier experiment and should be replaced...